### PR TITLE
ENH: Provide range of CMakes to cmake_minimum_required

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # define minimum version of cmake
-cmake_minimum_required (VERSION 3.5)
+cmake_minimum_required(VERSION 3.12...3.31)
 
 # define project name and its language
 project(eMELA CXX Fortran)
@@ -52,14 +52,14 @@ if(WITH_LHAPDF)
   add_definitions(-DUSE_LHAPDF)
   find_program(LHAPDF_CONFIG lhapdf-config REQUIRED)
   if (LHAPDF_CONFIG)
-     exec_program(${LHAPDF_CONFIG}
-     ARGS --cflags
+     execute_process(COMMAND ${LHAPDF_CONFIG} --cflags
      OUTPUT_VARIABLE LHAPDF_CXX_FLAGS
+     OUTPUT_STRIP_TRAILING_WHITESPACE
      )
      set(LHAPDF_CXX_FLAGS ${LHAPDF_CXX_FLAGS} CACHE STRING INTERNAL)
-     exec_program(${LHAPDF_CONFIG}
-     ARGS --libs
+     execute_process(COMMAND ${LHAPDF_CONFIG} --libs
      OUTPUT_VARIABLE LHAPDF_LIBRARIES
+     OUTPUT_STRIP_TRAILING_WHITESPACE
      )
      set(LHAPDF_LIBRARIES ${LHAPDF_LIBRARIES} CACHE STRING INTERNAL)
   endif(LHAPDF_CONFIG)
@@ -82,7 +82,11 @@ else(SHARED)
   add_library(eMELA STATIC ${source_files})
 endif(SHARED)
 
-target_link_libraries(eMELA ${LHAPDF_LIBRARIES} ${MELA_LIBRARIES})
+if(DEFINED MELA_LIBRARIES)
+  target_link_libraries(eMELA ${LHAPDF_LIBRARIES} ${MELA_LIBRARIES})
+else()
+  target_link_libraries(eMELA ${LHAPDF_LIBRARIES})
+endif()
 install(DIRECTORY ${PROJECT_SOURCE_DIR}/inc/eMELA DESTINATION include)
 install(TARGETS eMELA DESTINATION lib)
 


### PR DESCRIPTION
* Set lower bound of 3.12, when the range feature was introduced, and upper bound of 3.31, the current latest release.
   - c.f. https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html
* Use `execute_process` as `exec_program` has been deprecated since CMake 3.0.
   - c.f. https://cmake.org/cmake/help/latest/policy/CMP0153.html
* Avoid trailing whitespace in `target_link_libraries` if `MELA_LIBRARIES` is not set.
   - c.f. https://cmake.org/cmake/help/latest/policy/CMP0004.html

c.f. https://github.com/conda-forge/staged-recipes/pull/28141